### PR TITLE
consistency in form validation

### DIFF
--- a/frontend/src/app/auth/login.component.html
+++ b/frontend/src/app/auth/login.component.html
@@ -9,7 +9,7 @@
         <p class="form-error" role="alert">{{ error }}</p>
       }
 
-      <form (ngSubmit)="submit()" class="form-stack auth-form">
+      <form #loginForm="ngForm" (ngSubmit)="submit()" class="form-stack auth-form">
         <mat-form-field appearance="outline" class="full-width">
           <mat-label>Username</mat-label>
           <input
@@ -41,7 +41,7 @@
           color="primary"
           type="submit"
           class="full-width"
-          [disabled]="submitting"
+          [disabled]="submitting || loginForm.invalid"
         >
           {{ submitting ? 'Signing in…' : 'Sign in' }}
         </button>


### PR DESCRIPTION
fixed this issue: All forms use template-driven forms ( FormsModule +… ngModel ). This is perfectly valid, but  the register form mixes #registerForm="ngForm" with manual error handling ( serverError , user‐ nameServerError ), creating a hybrid pattern.